### PR TITLE
Release: Strip debugging flags and system paths

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,5 +26,8 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           binary_name: "k8xauth"
-          ldflags: "-X k8xauth/cmd.version=${{ env.RELEASE_VERSION }}"
+          ldflags: >-
+            -s -w
+            -X k8xauth/cmd.version=${{ env.RELEASE_VERSION }}
+          build_flags: "-trimpath"
           compress_assets: "OFF"


### PR DESCRIPTION
This pull request makes improvements to the build configuration in the `.github/workflows/release.yaml` file, primarily focusing on optimizing the Go binary output for releases.

Build optimization:

* Added `-s -w` flags to the `ldflags` parameter to strip debug information and reduce the binary size.
* Introduced `build_flags: "-trimpath"` to remove file system paths from the compiled binary, further improving reproducibility and security.